### PR TITLE
ホーム画面とアカウント画面で試合結果を表示する

### DIFF
--- a/lib/features/result.dart
+++ b/lib/features/result.dart
@@ -42,13 +42,13 @@ class CreateResultController extends AutoDisposeAsyncNotifier<void> {
     state = await AsyncValue.guard(() async {
       try {
         // TODO(ryotaiwamoto): validation
-        if (result.type == ResultTypes.singles.toString()) {
+        if (result.type == ResultTypes.singles.name) {
           if (result.opponents.first == 'id-unselected') {
             throw const AppException(message: '対戦相手を選択してください。');
           }
         }
 
-        if (result.type == ResultTypes.doubles.toString()) {
+        if (result.type == ResultTypes.doubles.name) {
           if (result.opponents.first == 'id-unselected' ||
               result.opponents[1] == 'id-unselected' ||
               result.partner == 'id-unselected') {

--- a/lib/features/result.dart
+++ b/lib/features/result.dart
@@ -6,6 +6,7 @@ import '../models/result.dart';
 import '../repositories/auth/auth_repository_impl.dart';
 import '../repositories/result/result_repository_impl.dart';
 import '../utils/exceptions/app_exception.dart';
+import '../utils/resylt_types.dart';
 
 /// ユーザーの results コレクションを購読する StreamProvider。
 final resultsProvider = StreamProvider.autoDispose<List<Result>>((ref) {
@@ -41,13 +42,13 @@ class CreateResultController extends AutoDisposeAsyncNotifier<void> {
     state = await AsyncValue.guard(() async {
       try {
         // TODO(ryotaiwamoto): validation
-        if (result.type == 'singles') {
+        if (result.type == ResultTypes.singles.toString()) {
           if (result.opponents.first == 'id-unselected') {
             throw const AppException(message: '対戦相手を選択してください。');
           }
         }
 
-        if (result.type == 'doubles') {
+        if (result.type == ResultTypes.doubles.toString()) {
           if (result.opponents.first == 'id-unselected' ||
               result.opponents[1] == 'id-unselected' ||
               result.partner == 'id-unselected') {

--- a/lib/features/toggle_button.dart
+++ b/lib/features/toggle_button.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-const List<Widget> types = <Widget>[
-  Text('Singles'),
-  Text('Doubles'),
-];
+import '../utils/resylt_types.dart';
+
+/// 表記のみ日本語
+final List<Widget> types =
+    ResultTypes.values.map((type) => Text(type.jpName)).toList();
 
 const List<bool> initTypes = [true, false];
 

--- a/lib/pages/account_page.dart
+++ b/lib/pages/account_page.dart
@@ -1,14 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../features/app_user.dart';
+import '../features/member.dart';
 import '../features/result.dart';
+import '../features/toggle_button.dart';
+import '../models/member.dart';
 import '../models/result.dart';
 import '../utils/constants/app_colors.dart';
 import '../utils/constants/measure.dart';
+import '../utils/extensions/date_time.dart';
 import '../utils/loading.dart';
+import '../utils/resylt_types.dart';
 import '../utils/text_styles.dart';
+import '../widgets/app_over_scroll_indicator.dart';
 import '../widgets/white_app_bar.dart';
 import 'settings_page.dart';
 
@@ -22,7 +29,9 @@ class AccountPage extends HookConsumerWidget {
           data: (data) => data?.userName,
           orElse: () => null,
         );
-    final results = ref.watch(resultsProvider).maybeWhen<List<List<Result>>>(
+    final results = ref
+        .watch(resultsProvider)
+        .maybeWhen<List<List<List<Result>>>>(
           data: (data) {
             // メンバーごとに分類されたリストを返す
             final rawResults = data;
@@ -30,7 +39,7 @@ class AccountPage extends HookConsumerWidget {
             final rawDoublesResults = <Result>[];
 
             for (final result in rawResults) {
-              if (result.type == 'singles') {
+              if (result.type == ResultTypes.singles.name) {
                 rawSinglesResults.add(result);
               } else {
                 rawDoublesResults.add(result);
@@ -113,7 +122,7 @@ class AccountPage extends HookConsumerWidget {
             }
             debugPrint('');
 
-            return <List<Result>>[];
+            return [singlesResults, doublesResults];
           },
           orElse: () => [],
         );
@@ -141,47 +150,78 @@ class AccountPage extends HookConsumerWidget {
               ),
             ],
           ),
-          body: Column(
-            children: [
-              Measure.g_32,
-              const Center(
-                child: Icon(
-                  Icons.account_circle,
-                  color: AppColors.primary,
-                  size: 128,
-                ),
-              ),
-              Measure.g_8,
-              Text(
-                appUserName ?? '',
-                style: TextStyles.h4(),
-              ),
-              Measure.g_24,
-              Padding(
+          body: AppOverScrollIndicator(
+            child: SingleChildScrollView(
+              child: Padding(
                 padding: Measure.p_h16,
                 child: Column(
                   children: [
-                    Row(
-                      children: [
-                        Text('Rate', style: TextStyles.h2()),
-                      ],
+                    Measure.g_32,
+                    const Center(
+                      child: Icon(
+                        Icons.account_circle,
+                        color: AppColors.primary,
+                        size: 96,
+                      ),
                     ),
                     Measure.g_8,
-                    // Flexible(
-                    //   child: ListView.builder(
-                    //     padding: Measure.p_h16,
-                    //     itemCount: results.length,
-                    //     itemBuilder: (BuildContext context, int index) {
-                    //       return _RateResultCard(
-                    //         results: results,
-                    //       );
-                    //     },
-                    //   ),
-                    // ),
+                    Text(
+                      appUserName ?? '',
+                      style: TextStyles.h4(),
+                    ),
+                    Measure.g_24,
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text('Rate', style: TextStyles.h2()),
+                    ),
+                    Measure.g_8,
+                    ToggleButtons(
+                      onPressed: (int index) {
+                        ref
+                            .watch(selectTypesProvider.notifier)
+                            .changeSelectType(index);
+                      },
+                      borderRadius: Measure.br_8,
+                      borderColor: AppColors.secondary,
+                      selectedColor: AppColors.baseWhite,
+                      fillColor: AppColors.secondary,
+                      color: AppColors.secondary,
+                      highlightColor: AppColors.secondaryPale,
+                      splashColor: AppColors.secondaryPale,
+                      constraints: const BoxConstraints(
+                        minHeight: 40,
+                        minWidth: 130,
+                      ),
+                      isSelected: ref.watch(selectTypesProvider),
+                      children: types,
+                    ),
+                    Measure.g_16,
+                    if (ref.watch(selectTypesProvider).first == true)
+                      Column(
+                        children: results[0]
+                            .map(
+                              (e) => _RateSinglesResultCard(
+                                results: results[0],
+                                index: results[0].indexOf(e),
+                              ),
+                            )
+                            .toList(),
+                      )
+                    else
+                      Column(
+                        children: results[1]
+                            .map(
+                              (e) => _RateDoublesResultCard(
+                                results: results[1],
+                                index: results[1].indexOf(e),
+                              ),
+                            )
+                            .toList(),
+                      ),
                   ],
                 ),
               ),
-            ],
+            ),
           ),
         ),
         if (ref.watch(overlayLoadingProvider)) const OverlayLoadingWidget(),
@@ -190,100 +230,282 @@ class AccountPage extends HookConsumerWidget {
   }
 }
 
-class _RateResultCard extends StatelessWidget {
-  const _RateResultCard({
+class _RateSinglesResultCard extends HookConsumerWidget {
+  const _RateSinglesResultCard({
     required this.results,
+    required this.index,
   });
 
-  final List<Result> results;
+  final List<List<Result>> results;
+  final int index;
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: const BoxDecoration(
-        color: AppColors.baseLight,
-        boxShadow: [
-          BoxShadow(
-            offset: Offset(1, 1),
-            blurRadius: 2,
-          )
-        ],
-      ),
-      width: double.infinity,
-      child: Padding(
-        padding: Measure.p_a8,
-        child: Column(
-          children: [
-            Container(
-              width: double.infinity,
-              color: AppColors.baseWhite,
-              child: Padding(
-                padding: Measure.p_a8,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(
-                      child: Column(
-                        children: [
-                          Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              'Jonatan Christie',
-                              style: TextStyles.p2(),
-                            ),
-                          ),
-                          Measure.g_4,
-                          const Divider(
-                            height: 0,
-                            thickness: 2,
-                          ),
-                          Measure.g_4,
-                          Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              'Thomas Rouxel',
-                              style: TextStyles.p2Bold(),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(
-                      width: 8,
-                    ),
-                    Center(
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.baseline,
-                        textBaseline: TextBaseline.alphabetic,
-                        children: [
-                          Text(
-                            '54',
-                            style: TextStyles.h1(),
-                          ),
-                          Align(
-                            child: Text(
-                              '%',
-                              style: TextStyles.h2(),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(left: 8, top: 8),
-              child: Align(
-                alignment: Alignment.bottomLeft,
-                child: Text(
-                  'Latest: 2022/03/25',
-                  style: TextStyles.p3(),
-                ),
-              ),
-            ),
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appUserName = ref.watch(appUserFutureProvider).maybeWhen<String?>(
+          data: (data) => data?.userName,
+          orElse: () => null,
+        );
+    final members = ref.watch(membersProvider).maybeWhen<List<Member>>(
+          data: (data) {
+            return data;
+          },
+          orElse: () => [],
+        );
+
+    final result = results[index][0];
+    return Padding(
+      padding: Measure.p_v4,
+      child: Container(
+        decoration: const BoxDecoration(
+          color: AppColors.baseLight,
+          boxShadow: [
+            BoxShadow(
+              offset: Offset(1, 1),
+              blurRadius: 2,
+            )
           ],
+        ),
+        width: double.infinity,
+        child: Padding(
+          padding: Measure.p_a8,
+          child: Column(
+            children: [
+              Container(
+                width: double.infinity,
+                color: AppColors.baseWhite,
+                child: Padding(
+                  padding: Measure.p_a8,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          children: [
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                appUserName ?? '',
+                                style: TextStyles.p2(),
+                              ),
+                            ),
+                            Measure.g_4,
+                            const Divider(
+                              height: 0,
+                              thickness: 2,
+                            ),
+                            Measure.g_4,
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                members.isNotEmpty
+                                    ? members
+                                        .firstWhere(
+                                          (element) =>
+                                              element.memberId ==
+                                              result.opponents[0],
+                                        )
+                                        .memberName
+                                    : '',
+                                style: TextStyles.p2(),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 8,
+                      ),
+                      Center(
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.baseline,
+                          textBaseline: TextBaseline.alphabetic,
+                          children: [
+                            Text(
+                              '54',
+                              style: TextStyles.h1(),
+                            ),
+                            Align(
+                              child: Text(
+                                '%',
+                                style: TextStyles.h2(),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 8, top: 8),
+                child: Align(
+                  alignment: Alignment.bottomLeft,
+                  child: Text(
+                    'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(withJapaneseWeekDay: false)}',
+                    style: TextStyles.p3(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RateDoublesResultCard extends HookConsumerWidget {
+  const _RateDoublesResultCard({
+    required this.results,
+    required this.index,
+  });
+
+  final List<List<Result>> results;
+  final int index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appUserName = ref.watch(appUserFutureProvider).maybeWhen<String?>(
+          data: (data) => data?.userName,
+          orElse: () => null,
+        );
+    final members = ref.watch(membersProvider).maybeWhen<List<Member>>(
+          data: (data) {
+            return data;
+          },
+          orElse: () => [],
+        );
+
+    final result = results[index][0];
+    return Padding(
+      padding: Measure.p_v4,
+      child: Container(
+        decoration: const BoxDecoration(
+          color: AppColors.baseLight,
+          boxShadow: [
+            BoxShadow(
+              offset: Offset(1, 1),
+              blurRadius: 2,
+            )
+          ],
+        ),
+        width: double.infinity,
+        child: Padding(
+          padding: Measure.p_a8,
+          child: Column(
+            children: [
+              Container(
+                width: double.infinity,
+                color: AppColors.baseWhite,
+                child: Padding(
+                  padding: Measure.p_a8,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          children: [
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                appUserName ?? '',
+                                style: TextStyles.p2(),
+                              ),
+                            ),
+                            const Gap(2),
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                members.isNotEmpty
+                                    ? members
+                                        .firstWhere(
+                                          (element) =>
+                                              element.memberId ==
+                                              result.partner,
+                                        )
+                                        .memberName
+                                    : '',
+                                style: TextStyles.p2(),
+                              ),
+                            ),
+                            Measure.g_4,
+                            const Divider(
+                              height: 0,
+                              thickness: 2,
+                            ),
+                            Measure.g_4,
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                members.isNotEmpty
+                                    ? members
+                                        .firstWhere(
+                                          (element) =>
+                                              element.memberId ==
+                                              result.opponents[0],
+                                        )
+                                        .memberName
+                                    : '',
+                                style: TextStyles.p2(),
+                              ),
+                            ),
+                            const Gap(2),
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                members.isNotEmpty
+                                    ? members
+                                        .firstWhere(
+                                          (element) =>
+                                              element.memberId ==
+                                              result.opponents[1],
+                                        )
+                                        .memberName
+                                    : '',
+                                style: TextStyles.p2(),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 8,
+                      ),
+                      Center(
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.baseline,
+                          textBaseline: TextBaseline.alphabetic,
+                          children: [
+                            Text(
+                              '54',
+                              style: TextStyles.h1(),
+                            ),
+                            Align(
+                              child: Text(
+                                '%',
+                                style: TextStyles.h2(),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 8, top: 8),
+                child: Align(
+                  alignment: Alignment.bottomLeft,
+                  child: Text(
+                    'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(withJapaneseWeekDay: false)}',
+                    style: TextStyles.p3(),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/pages/account_page.dart
+++ b/lib/pages/account_page.dart
@@ -342,7 +342,9 @@ class _RateSinglesResultCard extends HookConsumerWidget {
                 child: Align(
                   alignment: Alignment.bottomLeft,
                   child: Text(
-                    'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(withJapaneseWeekDay: false)}',
+                    '''
+Latest: ${result.createdAt.dateTime!.toYYYYMMDD(withJapaneseWeekDay: false)}
+''',
                     style: TextStyles.p3(),
                   ),
                 ),
@@ -499,7 +501,9 @@ class _RateDoublesResultCard extends HookConsumerWidget {
                 child: Align(
                   alignment: Alignment.bottomLeft,
                   child: Text(
-                    'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(withJapaneseWeekDay: false)}',
+                    '''
+Latest: ${result.createdAt.dateTime!.toYYYYMMDD(withJapaneseWeekDay: false)}
+''',
                     style: TextStyles.p3(),
                   ),
                 ),

--- a/lib/pages/account_page.dart
+++ b/lib/pages/account_page.dart
@@ -342,9 +342,9 @@ class _RateSinglesResultCard extends HookConsumerWidget {
                 child: Align(
                   alignment: Alignment.bottomLeft,
                   child: Text(
-                    '''
-Latest: ${result.createdAt.dateTime!.toYYYYMMDD(withJapaneseWeekDay: false)}
-''',
+                    'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(
+                      withJapaneseWeekDay: false,
+                    )}',
                     style: TextStyles.p3(),
                   ),
                 ),
@@ -501,9 +501,9 @@ class _RateDoublesResultCard extends HookConsumerWidget {
                 child: Align(
                   alignment: Alignment.bottomLeft,
                   child: Text(
-                    '''
-Latest: ${result.createdAt.dateTime!.toYYYYMMDD(withJapaneseWeekDay: false)}
-''',
+                    'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(
+                      withJapaneseWeekDay: false,
+                    )}',
                     style: TextStyles.p3(),
                   ),
                 ),

--- a/lib/pages/account_page.dart
+++ b/lib/pages/account_page.dart
@@ -3,6 +3,8 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../features/app_user.dart';
+import '../features/result.dart';
+import '../models/result.dart';
 import '../utils/constants/app_colors.dart';
 import '../utils/constants/measure.dart';
 import '../utils/loading.dart';
@@ -19,6 +21,101 @@ class AccountPage extends HookConsumerWidget {
     final appUserName = ref.watch(appUserFutureProvider).maybeWhen<String?>(
           data: (data) => data?.userName,
           orElse: () => null,
+        );
+    final results = ref.watch(resultsProvider).maybeWhen<List<List<Result>>>(
+          data: (data) {
+            // メンバーごとに分類されたリストを返す
+            final rawResults = data;
+            final rawSinglesResults = <Result>[];
+            final rawDoublesResults = <Result>[];
+
+            for (final result in rawResults) {
+              if (result.type == 'singles') {
+                rawSinglesResults.add(result);
+              } else {
+                rawDoublesResults.add(result);
+              }
+            }
+            debugPrint('/// 全試合結果をシングルスの二次元配列とダブルスの二次元配列に変換 ///');
+
+            debugPrint('///// 元の配列の要素数');
+            debugPrint('シングルス: ${rawSinglesResults.length}');
+            debugPrint('ダブルス: ${rawDoublesResults.length}');
+            debugPrint('');
+
+            /// シングルス: 対戦相手で分類した二次元配列
+            final singlesResults = <List<Result>>[];
+
+            for (final result in rawSinglesResults) {
+              if (rawSinglesResults.indexOf(result) == 0) {
+                singlesResults.add([result]);
+              } else {
+                if (singlesResults.any(
+                  (element) =>
+                      element.any((e) => e.opponents[0] == result.opponents[0]),
+                )) {
+                  singlesResults
+                      .firstWhere(
+                        (element) => element
+                            .any((e) => e.opponents[0] == result.opponents[0]),
+                      )
+                      .add(result);
+                } else {
+                  singlesResults.add([result]);
+                }
+              }
+            }
+
+            debugPrint('///// シングルス(二次元配列の要素数): ${singlesResults.length}');
+            for (final element in singlesResults) {
+              debugPrint(
+                '${singlesResults.indexOf(element)}番目の要素数: ${element.length}',
+              );
+            }
+            debugPrint('');
+
+            /// ダブルス: パートナーと対戦相手で分類した二次元配列
+            final doublesResults = <List<Result>>[];
+
+            for (final result in rawDoublesResults) {
+              if (rawDoublesResults.indexOf(result) == 0) {
+                doublesResults.add([result]);
+              } else {
+                if (doublesResults.any(
+                  (element) => element.any(
+                    (e) =>
+                        e.partner == result.partner &&
+                        e.opponents[0] == result.opponents[0] &&
+                        e.opponents[1] == result.opponents[1],
+                  ),
+                )) {
+                  doublesResults
+                      .firstWhere(
+                        (element) => element.any(
+                          (e) =>
+                              e.partner == result.partner &&
+                              e.opponents[0] == result.opponents[0] &&
+                              e.opponents[1] == result.opponents[1],
+                        ),
+                      )
+                      .add(result);
+                } else {
+                  doublesResults.add([result]);
+                }
+              }
+            }
+
+            debugPrint('///// ダブルス(二次元配列の要素数): ${doublesResults.length}');
+            for (final element in doublesResults) {
+              debugPrint(
+                '${doublesResults.indexOf(element)}番目の要素数: ${element.length}',
+              );
+            }
+            debugPrint('');
+
+            return <List<Result>>[];
+          },
+          orElse: () => [],
         );
 
     return Stack(
@@ -70,96 +167,17 @@ class AccountPage extends HookConsumerWidget {
                       ],
                     ),
                     Measure.g_8,
-                    Container(
-                      decoration: const BoxDecoration(
-                        color: AppColors.baseLight,
-                        boxShadow: [
-                          BoxShadow(
-                            offset: Offset(1, 1),
-                            blurRadius: 2,
-                          )
-                        ],
-                      ),
-                      width: double.infinity,
-                      child: Padding(
-                        padding: Measure.p_a8,
-                        child: Column(
-                          children: [
-                            Container(
-                              width: double.infinity,
-                              color: AppColors.baseWhite,
-                              child: Padding(
-                                padding: Measure.p_a8,
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Expanded(
-                                      child: Column(
-                                        children: [
-                                          Align(
-                                            alignment: Alignment.centerLeft,
-                                            child: Text(
-                                              'Jonatan Christie',
-                                              style: TextStyles.p2(),
-                                            ),
-                                          ),
-                                          Measure.g_4,
-                                          const Divider(
-                                            height: 0,
-                                            thickness: 2,
-                                          ),
-                                          Measure.g_4,
-                                          Align(
-                                            alignment: Alignment.centerLeft,
-                                            child: Text(
-                                              'Thomas Rouxel',
-                                              style: TextStyles.p2Bold(),
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                    const SizedBox(
-                                      width: 8,
-                                    ),
-                                    Center(
-                                      child: Row(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.baseline,
-                                        textBaseline: TextBaseline.alphabetic,
-                                        children: [
-                                          Text(
-                                            '54',
-                                            style: TextStyles.h1(),
-                                          ),
-                                          Align(
-                                            child: Text(
-                                              '%',
-                                              style: TextStyles.h2(),
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.only(left: 8, top: 8),
-                              child: Align(
-                                alignment: Alignment.bottomLeft,
-                                child: Text(
-                                  'Latest: 2022/03/25',
-                                  style: TextStyles.p3(),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    )
+                    // Flexible(
+                    //   child: ListView.builder(
+                    //     padding: Measure.p_h16,
+                    //     itemCount: results.length,
+                    //     itemBuilder: (BuildContext context, int index) {
+                    //       return _RateResultCard(
+                    //         results: results,
+                    //       );
+                    //     },
+                    //   ),
+                    // ),
                   ],
                 ),
               ),
@@ -168,6 +186,106 @@ class AccountPage extends HookConsumerWidget {
         ),
         if (ref.watch(overlayLoadingProvider)) const OverlayLoadingWidget(),
       ],
+    );
+  }
+}
+
+class _RateResultCard extends StatelessWidget {
+  const _RateResultCard({
+    required this.results,
+  });
+
+  final List<Result> results;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: AppColors.baseLight,
+        boxShadow: [
+          BoxShadow(
+            offset: Offset(1, 1),
+            blurRadius: 2,
+          )
+        ],
+      ),
+      width: double.infinity,
+      child: Padding(
+        padding: Measure.p_a8,
+        child: Column(
+          children: [
+            Container(
+              width: double.infinity,
+              color: AppColors.baseWhite,
+              child: Padding(
+                padding: Measure.p_a8,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        children: [
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              'Jonatan Christie',
+                              style: TextStyles.p2(),
+                            ),
+                          ),
+                          Measure.g_4,
+                          const Divider(
+                            height: 0,
+                            thickness: 2,
+                          ),
+                          Measure.g_4,
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              'Thomas Rouxel',
+                              style: TextStyles.p2Bold(),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(
+                      width: 8,
+                    ),
+                    Center(
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.baseline,
+                        textBaseline: TextBaseline.alphabetic,
+                        children: [
+                          Text(
+                            '54',
+                            style: TextStyles.h1(),
+                          ),
+                          Align(
+                            child: Text(
+                              '%',
+                              style: TextStyles.h2(),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 8, top: 8),
+              child: Align(
+                alignment: Alignment.bottomLeft,
+                child: Text(
+                  'Latest: 2022/03/25',
+                  style: TextStyles.p3(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/create_result_page.dart
+++ b/lib/pages/create_result_page.dart
@@ -18,6 +18,7 @@ import '../utils/fakes/member.dart';
 import '../utils/json_converters/union_timestamp.dart';
 import '../utils/loading.dart';
 import '../utils/result_format.dart';
+import '../utils/resylt_types.dart';
 import '../utils/scaffold_messenger_service.dart';
 import '../utils/text_styles.dart';
 import '../widgets/number_picker/numberpicker.dart';
@@ -123,8 +124,7 @@ class CreateResultPage extends HookConsumerWidget {
                               .watch(selectTypesProvider.notifier)
                               .changeSelectType(index);
                         },
-                        borderRadius:
-                            const BorderRadius.all(Radius.circular(8)),
+                        borderRadius: Measure.br_8,
                         borderColor: AppColors.secondary,
                         selectedColor: AppColors.baseWhite,
                         fillColor: AppColors.secondary,
@@ -397,8 +397,8 @@ class CreateResultPage extends HookConsumerWidget {
 
                           final result = Result(
                             type: ref.watch(selectTypesProvider).first == true
-                                ? 'singles'
-                                : 'doubles',
+                                ? ResultTypes.singles.name
+                                : ResultTypes.doubles.name,
                             partner: partner,
                             opponents: opponents,
                             yourScore: yourScore,

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -14,6 +14,7 @@ import '../utils/constants/app_colors.dart';
 import '../utils/constants/measure.dart';
 import '../utils/extensions/date_time.dart';
 import '../utils/text_styles.dart';
+import '../widgets/app_over_scroll_indicator.dart';
 import '../widgets/white_app_bar.dart';
 import 'account_page.dart';
 import 'create_result_page.dart';
@@ -52,21 +53,27 @@ class HomePage extends HookConsumerWidget {
             ),
           ],
         ),
-        body: Column(
-          children: [
-            const Gap(4),
-            Flexible(
-              child: ListView.builder(
-                padding: Measure.p_h16,
-                itemCount: results.length,
-                itemBuilder: (BuildContext context, int index) {
-                  return _MatchResultCard(
-                    result: results[index],
-                  );
-                },
+        body: AppOverScrollIndicator(
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: Measure.p_h16,
+              child: Column(
+                children: [
+                  const Gap(8),
+                  Column(
+                    children: results
+                        .map(
+                          (result) => _MatchResultCard(
+                            result: result,
+                          ),
+                        )
+                        .toList(),
+                  ),
+                  const Gap(8),
+                ],
               ),
             ),
-          ],
+          ),
         ),
         floatingActionButton: FloatingActionButton(
           backgroundColor: AppColors.secondary,

--- a/lib/utils/constants/app_colors.dart
+++ b/lib/utils/constants/app_colors.dart
@@ -11,6 +11,7 @@ class AppColors {
   static const baseBlack = Color(0xFF000000);
   static const baseWhite = Color(0xFFFFFFFF);
   static const baseLight = Color(0xFFD9D9D9);
+  static const baseDark = Color(0xFF8F8F8F);
 
   static const textColor = Color(0xFF4E4E4E);
 }

--- a/lib/utils/resylt_types.dart
+++ b/lib/utils/resylt_types.dart
@@ -1,0 +1,12 @@
+enum ResultTypes {
+  singles(jpName: 'シングルス', enName: 'Singles'),
+  doubles(jpName: 'ダブルス', enName: 'Doubles');
+
+  const ResultTypes({
+    required this.jpName,
+    required this.enName,
+  });
+
+  final String jpName;
+  final String enName;
+}

--- a/lib/widgets/app_over_scroll_indicator.dart
+++ b/lib/widgets/app_over_scroll_indicator.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+import '../utils/constants/app_colors.dart';
+
+class AppOverScrollIndicator extends StatelessWidget {
+  const AppOverScrollIndicator({required this.child, super.key});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlowingOverscrollIndicator(
+      axisDirection: AxisDirection.down,
+      color: AppColors.secondary,
+      child: NotificationListener<OverscrollIndicatorNotification>(
+        onNotification: (OverscrollIndicatorNotification notification) {
+          notification.disallowIndicator(); // disallowGlow()を呼ぶ
+          return false;
+        },
+        child: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
close #35 

## やったこと

- ホーム画面に試合結果のデータを表示
- アカウント画面に試合結果のデータを表示

## やっていないこと

- なし

## キャプチャ

![CleanShot 2023-01-18 at 15 47 38](https://user-images.githubusercontent.com/75112184/213103375-65d33909-7f8c-43f7-ad8e-5dd8dfc40024.gif)


## その他（実装上の懸念点や注意点などあれば記載）


