### PR TITLE
勝率を計算して表示

### DIFF
--- a/lib/pages/account_page.dart
+++ b/lib/pages/account_page.dart
@@ -249,8 +249,7 @@ class _RateSinglesResultCard extends HookConsumerWidget {
                                             .length /
                                         sameMemberResults.length *
                                         100)
-                                    .toStringAsFixed(1)
-                                    .toString(),
+                                    .toStringAsFixed(1),
                                 style: TextStyles.h1(),
                               ),
                               Align(
@@ -433,8 +432,7 @@ class _RateDoublesResultCard extends HookConsumerWidget {
                                             .length /
                                         sameMemberResults.length *
                                         100)
-                                    .toStringAsFixed(1)
-                                    .toString(),
+                                    .toStringAsFixed(1),
                                 style: TextStyles.h1(),
                               ),
                               Align(

--- a/lib/pages/account_page.dart
+++ b/lib/pages/account_page.dart
@@ -16,6 +16,7 @@ import '../utils/loading.dart';
 import '../utils/text_styles.dart';
 import '../widgets/app_over_scroll_indicator.dart';
 import '../widgets/white_app_bar.dart';
+import 'same_member_result_page.dart';
 import 'settings_page.dart';
 
 class AccountPage extends HookConsumerWidget {
@@ -133,6 +134,7 @@ class AccountPage extends HookConsumerWidget {
   }
 }
 
+/// シングルス用のカード
 class _RateSinglesResultCard extends HookConsumerWidget {
   const _RateSinglesResultCard({
     required this.results,
@@ -156,104 +158,128 @@ class _RateSinglesResultCard extends HookConsumerWidget {
         );
 
     final result = results[index][0];
-    return Padding(
-      padding: Measure.p_v4,
-      child: Container(
-        decoration: const BoxDecoration(
-          color: AppColors.baseLight,
-          borderRadius: Measure.br_4,
-          boxShadow: [
-            BoxShadow(
-              offset: Offset(1, 1),
-              blurRadius: 2,
-            )
-          ],
-        ),
-        width: double.infinity,
-        child: Padding(
-          padding: Measure.p_a8,
-          child: Column(
-            children: [
-              Container(
-                width: double.infinity,
-                color: AppColors.baseWhite,
-                child: Padding(
-                  padding: Measure.p_a8,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Expanded(
-                        child: Column(
-                          children: [
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                appUserName ?? '',
-                                style: TextStyles.p2(),
-                              ),
-                            ),
-                            Measure.g_4,
-                            const Divider(
-                              height: 0,
-                              thickness: 2,
-                            ),
-                            Measure.g_4,
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                members.isNotEmpty
-                                    ? members
-                                        .firstWhere(
-                                          (element) =>
-                                              element.memberId ==
-                                              result.opponents[0],
-                                        )
-                                        .memberName
-                                    : '',
-                                style: TextStyles.p2(),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 8,
-                      ),
-                      Center(
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.baseline,
-                          textBaseline: TextBaseline.alphabetic,
-                          children: [
-                            Text(
-                              '54',
-                              style: TextStyles.h1(),
-                            ),
-                            Align(
-                              child: Text(
-                                '%',
-                                style: TextStyles.h2(),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(left: 8, top: 8),
-                child: Align(
-                  alignment: Alignment.bottomLeft,
-                  child: Text(
-                    'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(
-                      withJapaneseWeekDay: false,
-                    )}',
-                    style: TextStyles.p3(),
-                  ),
-                ),
-              ),
+    final sameMemberResults = results[index];
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute<bool>(
+            builder: (_) => SameMemberResultPage(
+              results: sameMemberResults,
+            ),
+          ),
+        );
+      },
+      child: Padding(
+        padding: Measure.p_v4,
+        child: Container(
+          decoration: const BoxDecoration(
+            color: AppColors.baseLight,
+            borderRadius: Measure.br_4,
+            boxShadow: [
+              BoxShadow(
+                offset: Offset(1, 1),
+                blurRadius: 2,
+              )
             ],
+          ),
+          width: double.infinity,
+          child: Padding(
+            padding: Measure.p_a8,
+            child: Column(
+              children: [
+                Container(
+                  width: double.infinity,
+                  color: AppColors.baseWhite,
+                  child: Padding(
+                    padding: Measure.p_a8,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(
+                          child: Column(
+                            children: [
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  appUserName ?? '',
+                                  style: TextStyles.p2(),
+                                ),
+                              ),
+                              Measure.g_4,
+                              const Divider(
+                                height: 0,
+                                thickness: 2,
+                              ),
+                              Measure.g_4,
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  members.isNotEmpty
+                                      ? members
+                                          .firstWhere(
+                                            (element) =>
+                                                element.memberId ==
+                                                result.opponents[0],
+                                          )
+                                          .memberName
+                                      : '',
+                                  style: TextStyles.p2(),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(
+                          width: 8,
+                        ),
+                        Center(
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.baseline,
+                            textBaseline: TextBaseline.alphabetic,
+                            children: [
+                              Text(
+                                (sameMemberResults
+                                            .where(
+                                              (element) =>
+                                                  element.isWinner == true,
+                                            )
+                                            .length /
+                                        sameMemberResults.length *
+                                        100)
+                                    .toStringAsFixed(1)
+                                    .toString(),
+                                style: TextStyles.h1(),
+                              ),
+                              Align(
+                                child: Text(
+                                  '%',
+                                  style: TextStyles.h2(),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(left: 8, top: 8),
+                  child: Align(
+                    alignment: Alignment.bottomLeft,
+                    child: Text(
+                      'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(
+                        withJapaneseWeekDay: false,
+                      )}',
+                      style: TextStyles.p3(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -261,6 +287,7 @@ class _RateSinglesResultCard extends HookConsumerWidget {
   }
 }
 
+/// ダブルス用のカード
 class _RateDoublesResultCard extends HookConsumerWidget {
   const _RateDoublesResultCard({
     required this.results,
@@ -284,136 +311,159 @@ class _RateDoublesResultCard extends HookConsumerWidget {
         );
 
     final result = results[index][0];
-    return Padding(
-      padding: Measure.p_v4,
-      child: Container(
-        decoration: const BoxDecoration(
-          borderRadius: Measure.br_4,
-          color: AppColors.baseLight,
-          boxShadow: [
-            BoxShadow(
-              offset: Offset(1, 1),
-              blurRadius: 2,
-            )
-          ],
-        ),
-        width: double.infinity,
-        child: Padding(
-          padding: Measure.p_a8,
-          child: Column(
-            children: [
-              Container(
-                width: double.infinity,
-                color: AppColors.baseWhite,
-                child: Padding(
-                  padding: Measure.p_a8,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Expanded(
-                        child: Column(
-                          children: [
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                appUserName ?? '',
-                                style: TextStyles.p2(),
-                              ),
-                            ),
-                            const Gap(2),
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                members.isNotEmpty
-                                    ? members
-                                        .firstWhere(
-                                          (element) =>
-                                              element.memberId ==
-                                              result.partner,
-                                        )
-                                        .memberName
-                                    : '',
-                                style: TextStyles.p2(),
-                              ),
-                            ),
-                            Measure.g_4,
-                            const Divider(
-                              height: 0,
-                              thickness: 2,
-                            ),
-                            Measure.g_4,
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                members.isNotEmpty
-                                    ? members
-                                        .firstWhere(
-                                          (element) =>
-                                              element.memberId ==
-                                              result.opponents[0],
-                                        )
-                                        .memberName
-                                    : '',
-                                style: TextStyles.p2(),
-                              ),
-                            ),
-                            const Gap(2),
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                members.isNotEmpty
-                                    ? members
-                                        .firstWhere(
-                                          (element) =>
-                                              element.memberId ==
-                                              result.opponents[1],
-                                        )
-                                        .memberName
-                                    : '',
-                                style: TextStyles.p2(),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 8,
-                      ),
-                      Center(
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.baseline,
-                          textBaseline: TextBaseline.alphabetic,
-                          children: [
-                            Text(
-                              '54',
-                              style: TextStyles.h1(),
-                            ),
-                            Align(
-                              child: Text(
-                                '%',
-                                style: TextStyles.h2(),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(left: 8, top: 8),
-                child: Align(
-                  alignment: Alignment.bottomLeft,
-                  child: Text(
-                    'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(
-                      withJapaneseWeekDay: false,
-                    )}',
-                    style: TextStyles.p3(),
-                  ),
-                ),
-              ),
+    final sameMemberResults = results[index];
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute<bool>(
+            builder: (_) => SameMemberResultPage(
+              results: sameMemberResults,
+            ),
+          ),
+        );
+      },
+      child: Padding(
+        padding: Measure.p_v4,
+        child: Container(
+          decoration: const BoxDecoration(
+            borderRadius: Measure.br_4,
+            color: AppColors.baseLight,
+            boxShadow: [
+              BoxShadow(
+                offset: Offset(1, 1),
+                blurRadius: 2,
+              )
             ],
+          ),
+          width: double.infinity,
+          child: Padding(
+            padding: Measure.p_a8,
+            child: Column(
+              children: [
+                Container(
+                  width: double.infinity,
+                  color: AppColors.baseWhite,
+                  child: Padding(
+                    padding: Measure.p_a8,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(
+                          child: Column(
+                            children: [
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  appUserName ?? '',
+                                  style: TextStyles.p2(),
+                                ),
+                              ),
+                              const Gap(2),
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  members.isNotEmpty
+                                      ? members
+                                          .firstWhere(
+                                            (element) =>
+                                                element.memberId ==
+                                                result.partner,
+                                          )
+                                          .memberName
+                                      : '',
+                                  style: TextStyles.p2(),
+                                ),
+                              ),
+                              Measure.g_4,
+                              const Divider(
+                                height: 0,
+                                thickness: 2,
+                              ),
+                              Measure.g_4,
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  members.isNotEmpty
+                                      ? members
+                                          .firstWhere(
+                                            (element) =>
+                                                element.memberId ==
+                                                result.opponents[0],
+                                          )
+                                          .memberName
+                                      : '',
+                                  style: TextStyles.p2(),
+                                ),
+                              ),
+                              const Gap(2),
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  members.isNotEmpty
+                                      ? members
+                                          .firstWhere(
+                                            (element) =>
+                                                element.memberId ==
+                                                result.opponents[1],
+                                          )
+                                          .memberName
+                                      : '',
+                                  style: TextStyles.p2(),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(
+                          width: 8,
+                        ),
+                        Center(
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.baseline,
+                            textBaseline: TextBaseline.alphabetic,
+                            children: [
+                              Text(
+                                (sameMemberResults
+                                            .where(
+                                              (element) =>
+                                                  element.isWinner == true,
+                                            )
+                                            .length /
+                                        sameMemberResults.length *
+                                        100)
+                                    .toStringAsFixed(1)
+                                    .toString(),
+                                style: TextStyles.h1(),
+                              ),
+                              Align(
+                                child: Text(
+                                  '%',
+                                  style: TextStyles.h2(),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(left: 8, top: 8),
+                  child: Align(
+                    alignment: Alignment.bottomLeft,
+                    child: Text(
+                      'Latest: ${result.createdAt.dateTime!.toYYYYMMDD(
+                        withJapaneseWeekDay: false,
+                      )}',
+                      style: TextStyles.p3(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,24 +1,16 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../features/app_user.dart';
-import '../features/member.dart';
 import '../features/result.dart';
-import '../models/member.dart';
 import '../models/result.dart';
 import '../utils/constants/app_colors.dart';
 import '../utils/constants/measure.dart';
-import '../utils/extensions/date_time.dart';
-import '../utils/text_styles.dart';
 import '../widgets/app_over_scroll_indicator.dart';
+import '../widgets/match_result_card.dart';
 import '../widgets/white_app_bar.dart';
 import 'account_page.dart';
 import 'create_result_page.dart';
-import 'result_page.dart';
 
 class HomePage extends HookConsumerWidget {
   const HomePage({super.key});
@@ -64,7 +56,7 @@ class HomePage extends HookConsumerWidget {
                   Column(
                     children: results
                         .map(
-                          (result) => _MatchResultCard(
+                          (result) => MatchResultCard(
                             result: result,
                           ),
                         )
@@ -117,199 +109,4 @@ PageRouteBuilder<dynamic> _slideAnimationBuilder({required Widget widget}) {
       );
     },
   );
-}
-
-class _MatchResultCard extends HookConsumerWidget {
-  const _MatchResultCard({
-    required this.result,
-  });
-
-  final Result result;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // Provider
-    final appUserName = ref.watch(appUserFutureProvider).maybeWhen<String?>(
-          data: (data) => data?.userName,
-          orElse: () => null,
-        );
-    final members = ref.watch(membersProvider).maybeWhen<List<Member>>(
-          data: (data) {
-            return data;
-          },
-          orElse: () => [],
-        );
-
-    return Padding(
-      padding: Measure.p_v4,
-      child: DecoratedBox(
-        decoration: const BoxDecoration(
-          borderRadius: Measure.br_8,
-          boxShadow: [
-            BoxShadow(
-              offset: Offset(1, 1),
-              blurRadius: 2,
-            )
-          ],
-          color: AppColors.baseLight,
-        ),
-        child: InkWell(
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute<bool>(
-                builder: (_) => ResultPage(
-                  result: result,
-                ),
-              ),
-            );
-          },
-          child: SizedBox(
-            width: double.infinity,
-            child: Padding(
-              padding: Measure.p_a8,
-              child: Column(
-                children: [
-                  Container(
-                    width: double.infinity,
-                    decoration: result.isWinner
-                        ? const BoxDecoration(
-                            gradient: LinearGradient(
-                              stops: [
-                                0.6,
-                                1.0,
-                              ],
-                              colors: [
-                                AppColors.baseWhite,
-                                AppColors.accent,
-                              ],
-                              transform: GradientRotation(math.pi / 3),
-                            ),
-                          )
-                        : const BoxDecoration(
-                            color: AppColors.baseWhite,
-                          ),
-                    child: Padding(
-                      padding: Measure.p_a8,
-                      child: Column(
-                        children: [
-                          Row(
-                            // 自分/自チーム
-                            children: [
-                              Text(
-                                appUserName ?? '',
-                                style: result.isWinner
-                                    ? TextStyles.p1Bold()
-                                    : TextStyles.p1(),
-                              ),
-                            ],
-                          ),
-                          if (result.type == 'doubles')
-                            Column(
-                              children: [
-                                const Gap(4),
-                                Row(
-                                  // 自分/自チーム
-                                  children: [
-                                    Text(
-                                      members.isNotEmpty
-                                          ? members
-                                              .firstWhere(
-                                                (element) =>
-                                                    element.memberId ==
-                                                    result.partner,
-                                              )
-                                              .memberName
-                                          : '',
-                                      style: result.isWinner
-                                          ? TextStyles.p1Bold()
-                                          : TextStyles.p1(),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          const Gap(8),
-                          Row(
-                            // 対戦相手/チーム
-                            children: [
-                              Text(
-                                members.isNotEmpty
-                                    ? members
-                                        .firstWhere(
-                                          (element) =>
-                                              element.memberId ==
-                                              result.opponents[0],
-                                        )
-                                        .memberName
-                                    : '',
-                                style: !result.isWinner
-                                    ? TextStyles.p1Bold()
-                                    : TextStyles.p1(),
-                              ),
-                            ],
-                          ),
-                          if (result.type == 'doubles')
-                            Column(
-                              children: [
-                                const Gap(4),
-                                Row(
-                                  // 自分/自チーム
-                                  children: [
-                                    Text(
-                                      members.isNotEmpty
-                                          ? members
-                                              .firstWhere(
-                                                (element) =>
-                                                    element.memberId ==
-                                                    result.opponents[1],
-                                              )
-                                              .memberName
-                                          : '',
-                                      style: !result.isWinner
-                                          ? TextStyles.p1Bold()
-                                          : TextStyles.p1(),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      vertical: 4,
-                      horizontal: 8,
-                    ),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      // 対戦した日付の表示(アイコン+日付)
-                      children: [
-                        const Icon(
-                          Icons.watch_later,
-                          size: 18,
-                          color: AppColors.baseDark,
-                        ),
-                        Measure.g_8,
-                        Text(
-                          result.createdAt.dateTime!
-                              .toYYYYMMDDHHMM(withJapaneseWeekDay: false),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const Divider(
-                    height: 1,
-                    color: AppColors.textColor,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
 }

--- a/lib/pages/same_member_result_page.dart
+++ b/lib/pages/same_member_result_page.dart
@@ -1,13 +1,10 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../features/app_user.dart';
 import '../features/member.dart';
-import '../features/result.dart';
 import '../models/member.dart';
 import '../models/result.dart';
 import '../utils/constants/app_colors.dart';
@@ -16,107 +13,47 @@ import '../utils/extensions/date_time.dart';
 import '../utils/text_styles.dart';
 import '../widgets/app_over_scroll_indicator.dart';
 import '../widgets/white_app_bar.dart';
-import 'account_page.dart';
-import 'create_result_page.dart';
 import 'result_page.dart';
 
-class HomePage extends HookConsumerWidget {
-  const HomePage({super.key});
+class SameMemberResultPage extends HookConsumerWidget {
+  const SameMemberResultPage({
+    required this.results,
+    super.key,
+  });
+
+  final List<Result> results;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final results = ref.watch(resultsProvider).maybeWhen<List<Result>>(
-          data: (data) {
-            return data.sublist(0, data.length >= 50 ? 50 : data.length);
-          },
-          orElse: () => [],
-        );
-
-    return WillPopScope(
-      onWillPop: () async => false,
-      child: Scaffold(
-        appBar: WhiteAppBar(
-          title: '',
-          actions: [
-            IconButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute<bool>(
-                    builder: (_) => const AccountPage(),
-                  ),
-                );
-              },
-              icon: const FaIcon(
-                Icons.account_circle_rounded,
-                size: 32,
-              ),
-            ),
-          ],
-        ),
-        body: AppOverScrollIndicator(
-          child: SingleChildScrollView(
-            child: Padding(
-              padding: Measure.p_h16,
-              child: Column(
-                children: [
-                  Measure.g_8,
-                  Column(
-                    children: results
-                        .map(
-                          (result) => _MatchResultCard(
-                            result: result,
-                          ),
-                        )
-                        .toList(),
-                  ),
-                  Measure.g_8,
-                  Text('最新の試合結果を ${results.length} 件表示しています。'),
-                  Measure.g_16,
-                ],
-              ),
+    return Scaffold(
+      appBar: const WhiteAppBar(
+        title: '',
+        automaticallyImplyLeading: true,
+      ),
+      body: AppOverScrollIndicator(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: Measure.p_h16,
+            child: Column(
+              children: [
+                Measure.g_8,
+                Column(
+                  children: results
+                      .map(
+                        (result) => _MatchResultCard(
+                          result: result,
+                        ),
+                      )
+                      .toList(),
+                ),
+                Measure.g_8,
+              ],
             ),
           ),
-        ),
-        floatingActionButton: FloatingActionButton(
-          backgroundColor: AppColors.secondary,
-          child: const FaIcon(Icons.add),
-          onPressed: () {
-            Navigator.push<dynamic>(
-              context,
-              _slideAnimationBuilder(
-                widget: const CreateResultPage(),
-              ),
-            );
-          },
         ),
       ),
     );
   }
-}
-
-PageRouteBuilder<dynamic> _slideAnimationBuilder({required Widget widget}) {
-  return PageRouteBuilder<dynamic>(
-    transitionDuration: const Duration(milliseconds: 200),
-    reverseTransitionDuration: const Duration(milliseconds: 200),
-    fullscreenDialog: true,
-    pageBuilder: (context, animation, secondaryAnimation) {
-      // 表示する画面のWidget
-      return widget;
-    },
-    transitionsBuilder: (context, animation, secondaryAnimation, child) {
-      const begin = Offset(0, 1); // 下から上
-      // final Offset begin = Offset(0.0, -1.0); // 上から下
-      const end = Offset.zero;
-      final tween = Tween(begin: begin, end: end)
-          .chain(CurveTween(curve: Curves.easeInOut));
-      final offsetAnimation = animation.drive(tween);
-      return SlideTransition(
-        position: offsetAnimation,
-        child: child,
-      );
-    },
-  );
 }
 
 class _MatchResultCard extends HookConsumerWidget {
@@ -207,7 +144,7 @@ class _MatchResultCard extends HookConsumerWidget {
                           if (result.type == 'doubles')
                             Column(
                               children: [
-                                const Gap(4),
+                                Measure.g_4,
                                 Row(
                                   // 自分/自チーム
                                   children: [
@@ -229,7 +166,7 @@ class _MatchResultCard extends HookConsumerWidget {
                                 ),
                               ],
                             ),
-                          const Gap(8),
+                          Measure.g_8,
                           Row(
                             // 対戦相手/チーム
                             children: [
@@ -252,7 +189,7 @@ class _MatchResultCard extends HookConsumerWidget {
                           if (result.type == 'doubles')
                             Column(
                               children: [
-                                const Gap(4),
+                                Measure.g_4,
                                 Row(
                                   // 自分/自チーム
                                   children: [

--- a/lib/pages/same_member_result_page.dart
+++ b/lib/pages/same_member_result_page.dart
@@ -1,19 +1,11 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../features/app_user.dart';
-import '../features/member.dart';
-import '../models/member.dart';
 import '../models/result.dart';
-import '../utils/constants/app_colors.dart';
 import '../utils/constants/measure.dart';
-import '../utils/extensions/date_time.dart';
-import '../utils/text_styles.dart';
 import '../widgets/app_over_scroll_indicator.dart';
+import '../widgets/match_result_card.dart';
 import '../widgets/white_app_bar.dart';
-import 'result_page.dart';
 
 class SameMemberResultPage extends HookConsumerWidget {
   const SameMemberResultPage({
@@ -40,7 +32,7 @@ class SameMemberResultPage extends HookConsumerWidget {
                 Column(
                   children: results
                       .map(
-                        (result) => _MatchResultCard(
+                        (result) => MatchResultCard(
                           result: result,
                         ),
                       )
@@ -48,201 +40,6 @@ class SameMemberResultPage extends HookConsumerWidget {
                 ),
                 Measure.g_8,
               ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _MatchResultCard extends HookConsumerWidget {
-  const _MatchResultCard({
-    required this.result,
-  });
-
-  final Result result;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // Provider
-    final appUserName = ref.watch(appUserFutureProvider).maybeWhen<String?>(
-          data: (data) => data?.userName,
-          orElse: () => null,
-        );
-    final members = ref.watch(membersProvider).maybeWhen<List<Member>>(
-          data: (data) {
-            return data;
-          },
-          orElse: () => [],
-        );
-
-    return Padding(
-      padding: Measure.p_v4,
-      child: DecoratedBox(
-        decoration: const BoxDecoration(
-          borderRadius: Measure.br_8,
-          boxShadow: [
-            BoxShadow(
-              offset: Offset(1, 1),
-              blurRadius: 2,
-            )
-          ],
-          color: AppColors.baseLight,
-        ),
-        child: InkWell(
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute<bool>(
-                builder: (_) => ResultPage(
-                  result: result,
-                ),
-              ),
-            );
-          },
-          child: SizedBox(
-            width: double.infinity,
-            child: Padding(
-              padding: Measure.p_a8,
-              child: Column(
-                children: [
-                  Container(
-                    width: double.infinity,
-                    decoration: result.isWinner
-                        ? const BoxDecoration(
-                            gradient: LinearGradient(
-                              stops: [
-                                0.6,
-                                1.0,
-                              ],
-                              colors: [
-                                AppColors.baseWhite,
-                                AppColors.accent,
-                              ],
-                              transform: GradientRotation(math.pi / 3),
-                            ),
-                          )
-                        : const BoxDecoration(
-                            color: AppColors.baseWhite,
-                          ),
-                    child: Padding(
-                      padding: Measure.p_a8,
-                      child: Column(
-                        children: [
-                          Row(
-                            // 自分/自チーム
-                            children: [
-                              Text(
-                                appUserName ?? '',
-                                style: result.isWinner
-                                    ? TextStyles.p1Bold()
-                                    : TextStyles.p1(),
-                              ),
-                            ],
-                          ),
-                          if (result.type == 'doubles')
-                            Column(
-                              children: [
-                                Measure.g_4,
-                                Row(
-                                  // 自分/自チーム
-                                  children: [
-                                    Text(
-                                      members.isNotEmpty
-                                          ? members
-                                              .firstWhere(
-                                                (element) =>
-                                                    element.memberId ==
-                                                    result.partner,
-                                              )
-                                              .memberName
-                                          : '',
-                                      style: result.isWinner
-                                          ? TextStyles.p1Bold()
-                                          : TextStyles.p1(),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          Measure.g_8,
-                          Row(
-                            // 対戦相手/チーム
-                            children: [
-                              Text(
-                                members.isNotEmpty
-                                    ? members
-                                        .firstWhere(
-                                          (element) =>
-                                              element.memberId ==
-                                              result.opponents[0],
-                                        )
-                                        .memberName
-                                    : '',
-                                style: !result.isWinner
-                                    ? TextStyles.p1Bold()
-                                    : TextStyles.p1(),
-                              ),
-                            ],
-                          ),
-                          if (result.type == 'doubles')
-                            Column(
-                              children: [
-                                Measure.g_4,
-                                Row(
-                                  // 自分/自チーム
-                                  children: [
-                                    Text(
-                                      members.isNotEmpty
-                                          ? members
-                                              .firstWhere(
-                                                (element) =>
-                                                    element.memberId ==
-                                                    result.opponents[1],
-                                              )
-                                              .memberName
-                                          : '',
-                                      style: !result.isWinner
-                                          ? TextStyles.p1Bold()
-                                          : TextStyles.p1(),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      vertical: 4,
-                      horizontal: 8,
-                    ),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      // 対戦した日付の表示(アイコン+日付)
-                      children: [
-                        const Icon(
-                          Icons.watch_later,
-                          size: 18,
-                          color: AppColors.baseDark,
-                        ),
-                        Measure.g_8,
-                        Text(
-                          result.createdAt.dateTime!
-                              .toYYYYMMDDHHMM(withJapaneseWeekDay: false),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const Divider(
-                    height: 1,
-                    color: AppColors.textColor,
-                  ),
-                ],
-              ),
             ),
           ),
         ),

--- a/lib/widgets/match_result_card.dart
+++ b/lib/widgets/match_result_card.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -18,7 +17,6 @@ class MatchResultCard extends HookConsumerWidget {
   const MatchResultCard({
     required this.result,
     super.key,
-
   });
 
   final Result result;
@@ -126,7 +124,7 @@ class MatchResultCard extends HookConsumerWidget {
                                 ),
                               ],
                             ),
-                         Measure.g_4,
+                          Measure.g_4,
                           Row(
                             // 対戦相手/チーム
                             children: [

--- a/lib/widgets/match_result_card.dart
+++ b/lib/widgets/match_result_card.dart
@@ -1,0 +1,212 @@
+import 'dart:math' as math;
+
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../features/app_user.dart';
+import '../features/member.dart';
+import '../models/member.dart';
+import '../models/result.dart';
+import '../pages/result_page.dart';
+import '../utils/constants/app_colors.dart';
+import '../utils/constants/measure.dart';
+import '../utils/extensions/date_time.dart';
+import '../utils/text_styles.dart';
+
+class MatchResultCard extends HookConsumerWidget {
+  const MatchResultCard({
+    required this.result,
+    super.key,
+
+  });
+
+  final Result result;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Provider
+    final appUserName = ref.watch(appUserFutureProvider).maybeWhen<String?>(
+          data: (data) => data?.userName,
+          orElse: () => null,
+        );
+    final members = ref.watch(membersProvider).maybeWhen<List<Member>>(
+          data: (data) {
+            return data;
+          },
+          orElse: () => [],
+        );
+
+    return Padding(
+      padding: Measure.p_v4,
+      child: DecoratedBox(
+        decoration: const BoxDecoration(
+          borderRadius: Measure.br_8,
+          boxShadow: [
+            BoxShadow(
+              offset: Offset(1, 1),
+              blurRadius: 2,
+            )
+          ],
+          color: AppColors.baseLight,
+        ),
+        child: InkWell(
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute<bool>(
+                builder: (_) => ResultPage(
+                  result: result,
+                ),
+              ),
+            );
+          },
+          child: SizedBox(
+            width: double.infinity,
+            child: Padding(
+              padding: Measure.p_a8,
+              child: Column(
+                children: [
+                  Container(
+                    width: double.infinity,
+                    decoration: result.isWinner
+                        ? const BoxDecoration(
+                            gradient: LinearGradient(
+                              stops: [
+                                0.6,
+                                1.0,
+                              ],
+                              colors: [
+                                AppColors.baseWhite,
+                                AppColors.accent,
+                              ],
+                              transform: GradientRotation(math.pi / 3),
+                            ),
+                          )
+                        : const BoxDecoration(
+                            color: AppColors.baseWhite,
+                          ),
+                    child: Padding(
+                      padding: Measure.p_a8,
+                      child: Column(
+                        children: [
+                          Row(
+                            // 自分/自チーム
+                            children: [
+                              Text(
+                                appUserName ?? '',
+                                style: result.isWinner
+                                    ? TextStyles.p1Bold()
+                                    : TextStyles.p1(),
+                              ),
+                            ],
+                          ),
+                          if (result.type == 'doubles')
+                            Column(
+                              children: [
+                                Measure.g_4,
+                                Row(
+                                  // 自分/自チーム
+                                  children: [
+                                    Text(
+                                      members.isNotEmpty
+                                          ? members
+                                              .firstWhere(
+                                                (element) =>
+                                                    element.memberId ==
+                                                    result.partner,
+                                              )
+                                              .memberName
+                                          : '',
+                                      style: result.isWinner
+                                          ? TextStyles.p1Bold()
+                                          : TextStyles.p1(),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                         Measure.g_4,
+                          Row(
+                            // 対戦相手/チーム
+                            children: [
+                              Text(
+                                members.isNotEmpty
+                                    ? members
+                                        .firstWhere(
+                                          (element) =>
+                                              element.memberId ==
+                                              result.opponents[0],
+                                        )
+                                        .memberName
+                                    : '',
+                                style: !result.isWinner
+                                    ? TextStyles.p1Bold()
+                                    : TextStyles.p1(),
+                              ),
+                            ],
+                          ),
+                          if (result.type == 'doubles')
+                            Column(
+                              children: [
+                                Measure.g_4,
+                                Row(
+                                  // 自分/自チーム
+                                  children: [
+                                    Text(
+                                      members.isNotEmpty
+                                          ? members
+                                              .firstWhere(
+                                                (element) =>
+                                                    element.memberId ==
+                                                    result.opponents[1],
+                                              )
+                                              .memberName
+                                          : '',
+                                      style: !result.isWinner
+                                          ? TextStyles.p1Bold()
+                                          : TextStyles.p1(),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      vertical: 4,
+                      horizontal: 8,
+                    ),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      // 対戦した日付の表示(アイコン+日付)
+                      children: [
+                        const Icon(
+                          Icons.watch_later,
+                          size: 18,
+                          color: AppColors.baseDark,
+                        ),
+                        Measure.g_8,
+                        Text(
+                          result.createdAt.dateTime!
+                              .toYYYYMMDDHHMM(withJapaneseWeekDay: false),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Divider(
+                    height: 1,
+                    color: AppColors.textColor,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,308 +5,352 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      url: "https://pub.dev"
     source: hosted
-    version: "50.0.0"
+    version: "52.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      url: "https://pub.dartlang.org"
+      sha256: "3ff770dfff04a67b0863dff205a0936784de1b87a5e99b11c693fc10e66a9ce3"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.12"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.4.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: ed7cc591a948744994714375caf9a2ce89e1d82e8243997c8a2994d57181c212
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.5"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "7c35a3a7868626257d8aee47b51c26b9dba11eaddf3431117ed2744951416aab"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.7"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "169565c8ad06adb760c3645bf71f00bff161b00002cace266cad42c5d22a7725"
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.3"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      url: "https://pub.dartlang.org"
+      sha256: "66f86e916d285c1a93d3b79587d94bd71984a66aac4ff74e524cfa7877f1395c"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.5"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   cloud_firestore:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      url: "https://pub.dartlang.org"
+      sha256: a851106a2169c15614047b75ea10d0346650352c6669ab482306572aa4ed9a7d
+      url: "https://pub.dev"
     source: hosted
     version: "4.3.1"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "1fac512fef2bfe84ca7f372defbd9dd8efb108be96854db9023739a5b2aa9977"
+      url: "https://pub.dev"
     source: hosted
     version: "5.10.1"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      url: "https://pub.dartlang.org"
+      sha256: "3fd9581c1447b6e8db6d0f19d0140b196a70ecf582bd1f71e7141fe9abf10ddb"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
+      url: "https://pub.dev"
     source: hosted
     version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   color:
     dependency: transitive
     description:
       name: color
-      url: "https://pub.dartlang.org"
+      sha256: ddcdf1b3badd7008233f5acffaf20ca9f5dc2cd0172b75f68f24526a5f5725cb
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   connectivity_plus:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      url: "https://pub.dartlang.org"
+      sha256: "745ebcccb1ef73768386154428a55250bc8d44059c19fd27aecda2a6dc013a22"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: b8795b9238bf83b64375f63492034cb3d8e222af4d9ce59dda085edf038fa06f
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   csslib:
     dependency: transitive
     description:
       name: csslib
-      url: "https://pub.dartlang.org"
+      sha256: b36c7f7e24c0bdf1bf9a3da461c837d1de64b9f8beb190c9011d8c72a3dfd745
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
   dartx:
     dependency: transitive
     description:
       name: dartx
-      url: "https://pub.dartlang.org"
+      sha256: "45d7176701f16c5a5e00a4798791c1964bc231491b879369c818dd9a9c764871"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   dbus:
     dependency: transitive
     description:
       name: dbus
-      url: "https://pub.dartlang.org"
+      sha256: "6f07cba3f7b3448d42d015bfd3d53fe12e5b36da2423f23838efc1d5fb31a263"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.8"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      url: "https://pub.dartlang.org"
+      sha256: ac3c7c8022c1032c1dc7d16e62db1d6f1e2fbdc8c1039ee706d8deb45eca3a42
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.5"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "325d934e21826b3e7030f5018ef61927e2083b4c4fb25218ddef6ffc0012b717"
+      url: "https://pub.dev"
     source: hosted
     version: "6.11.7"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      url: "https://pub.dartlang.org"
+      sha256: "3fb9fafcd3541005a309c1a696f7df6294893a0c44f010f4ed1b0ded4793c858"
+      url: "https://pub.dev"
     source: hosted
     version: "5.2.4"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      url: "https://pub.dartlang.org"
+      sha256: c129209ba55f3d4272c89fb4a4994c15bea77fb6de63a82d45fb6bc5c94e4355
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "5fab93f5b354648efa62e7cc829c90efb68c8796eecf87e0888cae2d5f3accd4"
+      url: "https://pub.dev"
     source: hosted
     version: "4.5.2"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      url: "https://pub.dartlang.org"
+      sha256: "18b35ce111b0a4266abf723c825bcf9d4e2519d13638cc7f06f2a8dd960c75bc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   flutter:
@@ -318,35 +362,40 @@ packages:
     dependency: transitive
     description:
       name: flutter_gen_core
-      url: "https://pub.dartlang.org"
+      sha256: "8c5edb4db82dadf0d343b1be8bc5e878b66500eb79a583723147b1efb5749ccb"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.0+1"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       name: flutter_gen_runner
-      url: "https://pub.dartlang.org"
+      sha256: a77b51f955c7d829bf0d077993c88b3be66d496b6a2c2c0d8fdae7b46e0435b5
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.0+1"
   flutter_hooks:
     dependency: "direct main"
     description:
       name: flutter_hooks
-      url: "https://pub.dartlang.org"
+      sha256: "2b202559a4ed3656bbb7aae9d8b335fb0037b23acc7ae3f377d1ba0b95c21aec"
+      url: "https://pub.dev"
     source: hosted
     version: "0.18.5+1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
-      url: "https://pub.dartlang.org"
+      sha256: ce0e501cfc258907842238e4ca605e74b7fd1cdf04b3b43e86c43f3e40a1592c
+      url: "https://pub.dev"
     source: hosted
     version: "0.11.0"
   flutter_lints:
     dependency: transitive
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_localizations:
@@ -358,35 +407,40 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_native_splash
-      url: "https://pub.dartlang.org"
+      sha256: "6777a3abb974021a39b5fdd2d46a03ca390e03903b6351f21d10e7ecc969f12d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.16"
   flutter_riverpod:
     dependency: transitive
     description:
       name: flutter_riverpod
-      url: "https://pub.dartlang.org"
+      sha256: "0c997763ce06359ee4686553b74def84062e9d6929ac63f61fa02465c1f8e32c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   flutter_slidable:
     dependency: "direct main"
     description:
       name: flutter_slidable
-      url: "https://pub.dartlang.org"
+      sha256: "6c68e1fad129b4b807b2218ef4cf7f7f6f61c5ec8861c990dc2278d9d03cb09f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   flutter_spinkit:
     dependency: "direct main"
     description:
       name: flutter_spinkit
-      url: "https://pub.dartlang.org"
+      sha256: "77a2117c0517ff909221f3160b8eb20052ab5216107581168af574ac1f05dff8"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
-      url: "https://pub.dartlang.org"
+      sha256: "6ff9fa12892ae074092de2fa6a9938fb21dbabfdaa2ff57dc697ff912fc8d4b2"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.6"
   flutter_test:
@@ -403,280 +457,320 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      url: "https://pub.dartlang.org"
+      sha256: "875dbb9ec1ad30d68102019ceb682760d06c72747c1c5b7885781b95f88569cc"
+      url: "https://pub.dev"
     source: hosted
     version: "10.3.0"
   freezed:
     dependency: "direct main"
     description:
       name: freezed
-      url: "https://pub.dartlang.org"
+      sha256: e819441678f1679b719008ff2ff0ef045d66eed9f9ec81166ca0d9b02a187454
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      url: "https://pub.dartlang.org"
+      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   gap:
     dependency: "direct main"
     description:
       name: gap
-      url: "https://pub.dartlang.org"
+      sha256: "6e35ee60d5bbc61b0bec97cc5ba7ed32f62f1f62449e281ea77677479418a15d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   hooks_riverpod:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      url: "https://pub.dartlang.org"
+      sha256: "71695b2e1dfc22a39f1f9c67b798f8f8f1521f2d0349817d13ccdd5c4cd7acba"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   html:
     dependency: transitive
     description:
       name: html
-      url: "https://pub.dartlang.org"
+      sha256: d9793e10dbe0e6c364f4c59bf3e01fb33a9b2a674bc7a1081693dba0614b6269
+      url: "https://pub.dev"
     source: hosted
     version: "0.15.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   image:
     dependency: transitive
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "8e9d133755c3e84c73288363e6343157c383a0c6c56fc51afcc5d4d7180306d6"
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.0"
   infinite_listview:
     dependency: "direct main"
     description:
       name: infinite_listview
-      url: "https://pub.dartlang.org"
+      sha256: f6062c1720eb59be553dfa6b89813d3e8dd2f054538445aaa5edaddfa5195ce6
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      url: "https://pub.dartlang.org"
+      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      url: "https://pub.dartlang.org"
+      sha256: "040088d9eb2337f3a51ddabe35261e2fea1c351e3dd29d755ed1290b6b700a75"
+      url: "https://pub.dev"
     source: hosted
     version: "6.6.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   nm:
     dependency: transitive
     description:
       name: nm
-      url: "https://pub.dartlang.org"
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:
       name: path_drawing
-      url: "https://pub.dartlang.org"
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
-      url: "https://pub.dartlang.org"
+      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   pedantic_mono:
     dependency: "direct dev"
     description:
       name: pedantic_mono
-      url: "https://pub.dartlang.org"
+      sha256: a852298d064d51a31d24863fd464c4bbd58aba6dfc8affbbf8a651fd803ae1b4
+      url: "https://pub.dev"
     source: hosted
-    version: "1.20.1"
+    version: "1.21.1"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      url: "https://pub.dev"
     source: hosted
     version: "3.6.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   riverpod:
     dependency: transitive
     description:
       name: riverpod
-      url: "https://pub.dartlang.org"
+      sha256: "0f43c64f1f79c2112c843305a879a746587fb7c1e388f1d4717737796756e2c4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   simple_logger:
     dependency: "direct main"
     description:
       name: simple_logger
-      url: "https://pub.dartlang.org"
+      sha256: "0b0006199015a81c30041390b91e4c9561079d631541ffc317f76fd1181c9cc7"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.0+2"
   sky_engine:
@@ -688,191 +782,218 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: "2d79738b6bbf38a43920e2b8d189e9a3ce6cc201f4b8fc76be5e4fe377b1c38d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.6"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      url: "https://pub.dartlang.org"
+      sha256: "3b67aade1d52416149c633ba1bb36df44d97c6b51830c2198e934e3fca87ca1f"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   state_notifier:
     dependency: transitive
     description:
       name: state_notifier
-      url: "https://pub.dartlang.org"
+      sha256: "8fe42610f179b843b12371e40db58c9444f8757f8b69d181c97e50787caed289"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.2+1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   time:
     dependency: transitive
     description:
       name: time
-      url: "https://pub.dartlang.org"
+      sha256: "83427e11d9072e038364a5e4da559e85869b227cf699a541be0da74f14140124"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   universal_io:
     dependency: transitive
     description:
       name: universal_io
-      url: "https://pub.dartlang.org"
+      sha256: "79f78ddad839ee3aae3ec7c01eb4575faf0d5c860f8e5223bc9f9c17f7f03cef"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
-      url: "https://pub.dartlang.org"
+      sha256: "698fa0b4392effdc73e9e184403b627362eb5fbf904483ac9defbb1c2191d809"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.8"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      url: "https://pub.dartlang.org"
+      sha256: "3e2f6dfd2c7d9cd123296cab8ef66cfc2c1a13f5845f42c7a0f365690a8a7dd1"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.23"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      url: "https://pub.dartlang.org"
+      sha256: bb328b24d3bccc20bdf1024a0990ac4f869d57663660de9c936fb8c043edefe3
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.18"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      url: "https://pub.dartlang.org"
+      sha256: "318c42cba924e18180c029be69caf0a1a710191b9ec49bb42b5998fdcccee3cc"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      url: "https://pub.dartlang.org"
+      sha256: "41988b55570df53b3dd2a7fc90c76756a963de6a8c5f8e113330cb35992e2094"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "4eae912628763eb48fc214522e58e942fd16ce195407dbf45638239523c759a6"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      url: "https://pub.dartlang.org"
+      sha256: "44d79408ce9f07052095ef1f9a693c258d6373dc3944249374e30eff7219ccb0"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.14"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      url: "https://pub.dartlang.org"
+      sha256: b6217370f8eb1fd85c8890c539f5a639a01ab209a36db82c921ebeacefc7a615
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: "979ee37d622dec6365e2efa4d906c37470995871fe9ae080d967e192d88286b5"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.2.2"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.6 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.0.0"


### PR DESCRIPTION
close #45 

## やったこと

- 勝率を計算して表示するようにした。少数第二位を四捨五入。
- アカウントページの試合結果から同メンバーでの試合一覧画面に遷移し、その後各試合結果の画面の遷移するようにした

## やっていないこと

- なし

## キャプチャ

<img src="https://user-images.githubusercontent.com/75112184/214972131-183b5648-1ea4-4c6d-9c43-7387413c7243.png" width=300>

## その他（実装上の懸念点や注意点などあれば記載）


